### PR TITLE
Handle mesh-provider IBC Failure Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ internal/
 *.log
 
 schema
+
+.DS_Store

--- a/contracts/mesh-provider/src/contract.rs
+++ b/contracts/mesh-provider/src/contract.rs
@@ -47,8 +47,6 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &state)?;
     RETRIES.save(deps.storage, &RetryState {
         list_validators_retries_remaining: LIST_VALIDATORS_MAX_RETRIES,
-        stake_retries_remaining: STAKE_MAX_RETRIES,
-        unstake_retries_remaining: UNSTAKE_MAX_RETRIES,
     })?;
 
     // Set packet time from msg or set default

--- a/contracts/mesh-provider/src/error.rs
+++ b/contracts/mesh-provider/src/error.rs
@@ -72,6 +72,9 @@ pub enum ContractError {
     #[error("Rewards amount is 0")]
     ZeroRewardsToSend {},
 
+    #[error("Unable to communicate for message: {0} on channel: {1}")]
+    NoResponse(String, String),
+
     #[error("Custom Error val: {val:?}")]
     CustomError { val: String },
     // Add any other custom errors you like here.

--- a/contracts/mesh-provider/src/ibc.rs
+++ b/contracts/mesh-provider/src/ibc.rs
@@ -3,19 +3,17 @@ use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
     from_slice, to_binary, Coin, Deps, DepsMut, Env, Ibc3ChannelOpenResponse, IbcBasicResponse,
-    IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout, Uint128,
+    IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout, Uint128, Event, StdError, IbcPacketAckMsg,
 };
 
-use cw_utils::Expiration;
 use mesh_ibc::{
     check_order, check_version, ConsumerMsg, ListValidatorsResponse, ProviderMsg, RewardsResponse,
     StdAck, UpdateValidatorsResponse,
 };
 
 use crate::error::ContractError;
-use crate::state::{ValStatus, Validator, CHANNEL, CONFIG, PACKET_LIFETIME, PORT, VALIDATORS, STAKED, CLAIMS};
-use crate::contract::LIST_VALIDATORS_RETRIES;
+use crate::state::{ValStatus, Validator, CHANNEL, CONFIG, PACKET_LIFETIME, PORT, VALIDATORS, STAKED, RETRIES};
 
 pub fn build_timeout(deps: Deps, env: &Env) -> Result<IbcTimeout, ContractError> {
     let packet_time = PACKET_LIFETIME.load(deps.storage)?;
@@ -181,7 +179,6 @@ pub fn ibc_packet_ack(
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
     let res: StdAck = from_slice(&msg.acknowledgement.data)?;
-
     // we need to handle the ack based on our request
     let original_packet: ProviderMsg = from_slice(&msg.original_packet.data)?;
     match (original_packet, res.is_ok()) {
@@ -196,16 +193,24 @@ pub fn ibc_packet_ack(
                 validator,
                 amount,
             },
-            false,
-        ) => fail_stake(deps, key, validator, amount),
+            true,
+        ) => ack_stake(deps, key, validator, amount),
         (
-            ProviderMsg::Unstake {
+            ProviderMsg::Stake {
                 key,
                 validator,
                 amount,
+            },
+            false,
+        ) => fail_stake(deps, env, key, validator, amount),
+        (
+            ProviderMsg::Unstake {
+                key: _,
+                validator: _,
+                amount: _,
             },
             true,
-        ) => ack_unstake(deps, env, key, validator, amount),
+        ) => ack_unstake(deps),
         (
             ProviderMsg::Unstake {
                 key,
@@ -213,8 +218,7 @@ pub fn ibc_packet_ack(
                 amount,
             },
             false,
-        ) => fail_unstake(deps, key, validator, amount),
-        (_, true) => Ok(IbcBasicResponse::new()),
+        ) => fail_unstake(deps, env, key, validator, amount),
     }
 }
 
@@ -231,12 +235,12 @@ pub fn ibc_packet_timeout(
             key,
             validator,
             amount,
-        } => fail_stake(deps, key, validator, amount),
+        } => fail_stake(deps, env, key, validator, amount),
         ProviderMsg::Unstake {
             key,
             validator,
             amount,
-        } => fail_unstake(deps, key, validator, amount),
+        } => fail_unstake(deps, env, key, validator, amount),
     }
 }
 
@@ -248,102 +252,44 @@ pub fn ack_list_validators(
     for val in res.validators {
         VALIDATORS.save(deps.storage, &val, &Validator::new())?;
     }
-
-    // reset retry counter
-    let mut config = CONFIG.load(deps.storage)?;
-    config.list_validators_retries_remaining = LIST_VALIDATORS_RETRIES;
-    CONFIG.save(deps.storage, &config)?;
-
-    Ok(IbcBasicResponse::new())
+    RETRIES.update(deps.storage, |mut r| -> Result<crate::state::RetryState, StdError> {
+        r.list_validators_reset();
+        Ok(r)
+    })?;
+    Ok(IbcBasicResponse::new()
+        .add_attribute("action", "ack list_validators"))
 }
 
 pub fn fail_list_validators(deps: DepsMut, env: Env) -> Result<IbcBasicResponse, ContractError> {
     // check if we should retry
-    let cfg = CONFIG.load(deps.storage)?;
-    let channel_id = CHANNEL.load(deps.storage)?;
-    if cfg.list_validators_retries_remaining <= 0 {
-        return Err(ContractError::NoResponse("list_validators".to_string(), channel_id))
+    let mut retries = RETRIES.load(deps.storage)?;
+    if !retries.list_validators_should_retry() {
+        retries.list_validators_reset();
+        RETRIES.save(deps.storage, &retries)?;
+        return Ok(IbcBasicResponse::new().add_event(Event::new("list_validators_fail")))
     }
-    let mut cfg_after = cfg.clone();
-    cfg_after.list_validators_retries_remaining -= 1;
-    CONFIG.save(deps.storage, &cfg_after)?;
+    RETRIES.save(deps.storage, &retries)?;
 
     // retry
+    let channel_id = CHANNEL.load(deps.storage)?;
     let packet = ProviderMsg::ListValidators {};
     let msg = IbcMsg::SendPacket {
         channel_id: channel_id,
         data: to_binary(&packet)?,
         timeout: build_timeout(deps.as_ref(), &env)?,
     };
-    Ok(IbcBasicResponse::new().add_message(msg))
+    Ok(IbcBasicResponse::new()
+        .add_event(Event::new("list_validators_retry"))
+        .add_message(msg))
 }
 
-pub fn fail_stake(
-    deps: DepsMut,
-    // _staker is the staker Addr, not used by consumer
-    staker: String,
-    validator: String,
-    amount: Uint128,
-) -> Result<IbcBasicResponse, ContractError> {
+fn ack_stake(deps: DepsMut, staker: String, validator: String, amount: Uint128) -> Result<IbcBasicResponse, ContractError> {
     let staker = deps.api.addr_validate(&staker)?;
 
     if amount.is_zero() {
-        return Err(ContractError::ZeroAmount);
+        return Ok(IbcBasicResponse::new().add_event(Event::new("ack_stake_zero_amount")));
     }
 
-    let mut val = VALIDATORS
-        .may_load(deps.storage, &validator)?
-        .ok_or_else(|| ContractError::UnknownValidator(validator.clone()))?;
-    let mut stake = STAKED
-        .may_load(deps.storage, (&staker, &validator))?
-        .unwrap_or_default();
-    stake.unstake_validator(&mut val, amount)?;
-    STAKED.save(deps.storage, (&staker, &validator), &stake)?;
-    VALIDATORS.save(deps.storage, &validator, &val)?;
-    Ok(IbcBasicResponse::new())
-}
-
-pub fn ack_unstake(
-    deps: DepsMut,
-    env: Env,
-    staker: String,
-    _validator: String,
-    amount: Uint128
-) -> Result<IbcBasicResponse , ContractError> {
-    let staker = deps.api.addr_validate(&staker)?;
-
-    if amount.is_zero() {
-        return Err(ContractError::ZeroAmount);
-    }
-
-    // create a future claim on number of shares (so we can adjust for later slashing)
-    let cfg = CONFIG.load(deps.storage)?;
-    let ready = env.block.time.plus_seconds(cfg.unbonding_period);
-    CLAIMS.create_claim(
-        deps.storage,
-        &staker,
-        amount,
-        Expiration::AtTime(ready),
-    )?;
-
-    // TODO: How should the user be notified of the failure?
-    Ok(IbcBasicResponse::new())
-}
-
-pub fn fail_unstake(
-    deps: DepsMut,
-    // _staker is the staker Addr, not used by consumer
-    staker: String,
-    validator: String,
-    amount: Uint128,
-) -> Result<IbcBasicResponse, ContractError> {
-    let staker = deps.api.addr_validate(&staker)?;
-
-    if amount.is_zero() {
-        return Err(ContractError::ZeroAmount);
-    }
-
-    // revert state changes associated with stake
     let mut val = VALIDATORS
         .may_load(deps.storage, &validator)?
         .ok_or_else(|| ContractError::UnknownValidator(validator.clone()))?;
@@ -351,7 +297,83 @@ pub fn fail_unstake(
     stake.stake_validator(&mut val, amount);
     STAKED.save(deps.storage, (&staker, &validator), &stake)?;
     VALIDATORS.save(deps.storage, &validator, &val)?;
+    RETRIES.update(deps.storage, |mut r| -> Result<crate::state::RetryState, StdError> {
+        r.stake_reset();
+        Ok(r)
+    })?;
 
-    // TODO: How should the user be notified of the failure?
-    Ok(IbcBasicResponse::new())
+    Ok(IbcBasicResponse::new()
+        .add_event(Event::new("ack_stake")))
+}
+
+pub fn fail_stake(
+    deps: DepsMut,
+    env: Env,
+    staker: String,
+    validator: String,
+    amount: Uint128,
+) -> Result<IbcBasicResponse, ContractError> {
+    let mut retries = RETRIES.load(deps.storage)?;
+    if !retries.stake_should_retry() {
+        retries.stake_reset();
+        RETRIES.save(deps.storage, &retries)?;
+        return Ok(IbcBasicResponse::new().add_event(Event::new("fail_stake")))
+    }
+    RETRIES.save(deps.storage, &retries)?;
+
+    let packet = ProviderMsg::Stake {
+        validator,
+        amount,
+        key: staker.into(),
+    };
+    let msg = IbcMsg::SendPacket {
+        channel_id: CHANNEL.load(deps.storage)?,
+        data: to_binary(&packet)?,
+        timeout: build_timeout(deps.as_ref(), &env)?,
+    };
+    Ok(IbcBasicResponse::new()
+        .add_event(Event::new("retry_stake"))
+        .add_message(msg))
+}
+
+pub fn ack_unstake(
+    deps: DepsMut,
+) -> Result<IbcBasicResponse , ContractError> {
+    RETRIES.update(deps.storage, |mut r| -> Result<crate::state::RetryState, StdError> {
+        r.unstake_reset();
+        Ok(r)
+    })?;
+    Ok(IbcBasicResponse::new().add_event(Event::new("ack_unstake")))
+}
+
+pub fn fail_unstake(
+    deps: DepsMut,
+    env: Env,
+    staker: String,
+    validator: String,
+    amount: Uint128,
+) -> Result<IbcBasicResponse, ContractError> {
+    // check if we should retry
+    let mut retries = RETRIES.load(deps.storage)?;
+    if !retries.unstake_should_retry() {
+        retries.unstake_reset();
+        RETRIES.save(deps.storage, &retries)?;
+        return Ok(IbcBasicResponse::new().add_event(Event::new("fail_unstake")))
+    }
+    RETRIES.save(deps.storage, &retries)?;
+
+    // retry
+    let packet = ProviderMsg::Unstake {
+        validator,
+        amount,
+        key: staker.to_string(),
+    };
+    let msg = IbcMsg::SendPacket {
+        channel_id: CHANNEL.load(deps.storage)?,
+        data: to_binary(&packet)?,
+        timeout: build_timeout(deps.as_ref(), &env)?,
+    };
+    Ok(IbcBasicResponse::new()
+        .add_event(Event::new("retry_unstake"))
+        .add_message(msg))
 }

--- a/contracts/mesh-provider/src/state.rs
+++ b/contracts/mesh-provider/src/state.rs
@@ -27,8 +27,6 @@ pub const UNSTAKE_MAX_RETRIES: u32 = 5;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct RetryState {
     pub list_validators_retries_remaining: u32,
-    pub stake_retries_remaining: u32,
-    pub unstake_retries_remaining: u32,
 }
 
 impl RetryState {
@@ -37,26 +35,8 @@ impl RetryState {
         0 < self.list_validators_retries_remaining
     }
 
-    pub fn stake_should_retry(&mut self) -> bool {
-        self.stake_retries_remaining -= 1;
-        0 < self.stake_retries_remaining
-    }
-
-    pub fn unstake_should_retry(&mut self) -> bool {
-        self.unstake_retries_remaining -= 1;
-        0 < self.unstake_retries_remaining
-    }
-
     pub fn list_validators_reset(&mut self) {
         self.list_validators_retries_remaining = LIST_VALIDATORS_MAX_RETRIES;
-    }
-
-    pub fn stake_reset(&mut self) {
-        self.stake_retries_remaining = STAKE_MAX_RETRIES;
-    }
-
-    pub fn unstake_reset(&mut self) {
-        self.unstake_retries_remaining = UNSTAKE_MAX_RETRIES;
     }
 }
 

--- a/contracts/mesh-provider/src/state.rs
+++ b/contracts/mesh-provider/src/state.rs
@@ -18,14 +18,55 @@ pub struct Config {
     pub unbonding_period: u64,
     /// IBC denom string - "port_id/channel_id/denom"
     pub rewards_ibc_denom: String,
-    /// The number of retries remaining to query mesh-consumer
+}
+
+pub const LIST_VALIDATORS_MAX_RETRIES: u32 = 5;
+pub const STAKE_MAX_RETRIES: u32 = 5;
+pub const UNSTAKE_MAX_RETRIES: u32 = 5;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RetryState {
     pub list_validators_retries_remaining: u32,
+    pub stake_retries_remaining: u32,
+    pub unstake_retries_remaining: u32,
+}
+
+impl RetryState {
+    pub fn list_validators_should_retry(&mut self) -> bool {
+        self.list_validators_retries_remaining -= 1;
+        0 < self.list_validators_retries_remaining
+    }
+
+    pub fn stake_should_retry(&mut self) -> bool {
+        self.stake_retries_remaining -= 1;
+        0 < self.stake_retries_remaining
+    }
+
+    pub fn unstake_should_retry(&mut self) -> bool {
+        self.unstake_retries_remaining -= 1;
+        0 < self.unstake_retries_remaining
+    }
+
+    pub fn list_validators_reset(&mut self) {
+        self.list_validators_retries_remaining = LIST_VALIDATORS_MAX_RETRIES;
+    }
+
+    pub fn stake_reset(&mut self) {
+        self.stake_retries_remaining = STAKE_MAX_RETRIES;
+    }
+
+    pub fn unstake_reset(&mut self) {
+        self.unstake_retries_remaining = UNSTAKE_MAX_RETRIES;
+    }
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const PACKET_LIFETIME: Item<u64> = Item::new("packet_time");
 pub const CHANNEL: Item<String> = Item::new("channel");
 pub const PORT: Item<String> = Item::new("port");
+
+// The number of retries remaining to query mesh-consumer
+pub const RETRIES: Item<RetryState> = Item::new("retry_state");
 
 // info on each validator, including voting and slashing
 pub const VALIDATORS: Map<&str, Validator> = Map::new("validators");

--- a/contracts/mesh-provider/src/state.rs
+++ b/contracts/mesh-provider/src/state.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub unbonding_period: u64,
     /// IBC denom string - "port_id/channel_id/denom"
     pub rewards_ibc_denom: String,
+    /// The number of retries remaining to query mesh-consumer
+    pub list_validators_retries_remaining: u32,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/tests/src/cosmwasm.spec.ts
+++ b/tests/src/cosmwasm.spec.ts
@@ -34,17 +34,17 @@ let osmosisIds: Record<string, number> = {};
 test.before(async (t) => {
   console.debug("Upload contracts to wasmd...");
   const wasmContracts = {
-    mesh_consumer: "./internal/mesh_consumer.wasm",
-    meta_staking: "./internal/meta_staking.wasm",
+    mesh_consumer: "./src/contracts/mesh_consumer.wasm",
+    meta_staking: "./src/contracts/meta_staking.wasm",
   };
   const wasmSign = await setupWasmClient();
   wasmIds = await setupContracts(wasmSign, wasmContracts);
 
   console.debug("Upload contracts to osmosis...");
   const osmosisContracts = {
-    mesh_lockup: "./internal/mesh_lockup.wasm",
-    mesh_provider: "./internal/mesh_provider.wasm",
-    mesh_slasher: "./internal/mesh_slasher.wasm",
+    mesh_lockup: "./src/contracts/mesh_lockup.wasm",
+    mesh_provider: "./src/contracts/mesh_provider.wasm",
+    mesh_slasher: "./src/contracts/mesh_slasher.wasm",
   };
   const osmosisSign = await setupOsmosisClient();
   osmosisIds = await setupContracts(osmosisSign, osmosisContracts);


### PR DESCRIPTION
EDIT 10/19

I went through and implemented some todos related to IBC failures in mesh-provider. The only unintuitive change involves a shift from unilateral staking to bilateral staking. That is, mesh-provider only updates its staking state after it receives confirmation via ack from mesh-consumer on the "stake" IBC call. By contrast, mesh-provider continues to offer unilateral unstaking, since we must assume that the consumer chain might be byzantine.

## Qs
* @ethanfrey is there a way to mock IBC calls for testing?

Closes #37 