### PR TITLE
Ci fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,6 @@ dependencies = [
  "mesh-apis",
  "mesh-ibc",
  "mesh-testing",
- "meta-staking",
  "schemars",
  "serde",
  "thiserror",

--- a/contracts/mesh-consumer/Cargo.toml
+++ b/contracts/mesh-consumer/Cargo.toml
@@ -34,7 +34,6 @@ cw-storage-plus  = { workspace = true }
 cw2              = { workspace = true }
 mesh-apis        = { workspace = true }
 mesh-ibc         = { workspace = true }
-meta-staking     = { workspace = true, features = ["library"] }
 schemars         = { workspace = true }
 serde            = { workspace = true }
 thiserror        = { workspace = true }

--- a/contracts/mesh-consumer/src/ibc.rs
+++ b/contracts/mesh-consumer/src/ibc.rs
@@ -7,8 +7,8 @@ use cosmwasm_std::{
     IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout, Uint128, WasmMsg,
 };
 
-use mesh_ibc::{check_order, check_version, ConsumerMsg, ProviderMsg, StdAck};
 use mesh_apis::StakingExecuteMsg;
+use mesh_ibc::{check_order, check_version, ConsumerMsg, ProviderMsg, StdAck};
 
 use crate::error::ContractError;
 use crate::state::{CHANNEL, CONFIG, PACKET_LIFETIME};

--- a/contracts/mesh-consumer/src/ibc.rs
+++ b/contracts/mesh-consumer/src/ibc.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 };
 
 use mesh_ibc::{check_order, check_version, ConsumerMsg, ProviderMsg, StdAck};
-use meta_staking::msg::ExecuteMsg as MetaStakingExecuteMsg;
+use mesh_apis::StakingExecuteMsg;
 
 use crate::error::ContractError;
 use crate::state::{CHANNEL, CONFIG, PACKET_LIFETIME};
@@ -143,7 +143,7 @@ pub fn receive_stake(
 
     let msg = WasmMsg::Execute {
         contract_addr: config.meta_staking_contract_address.to_string(),
-        msg: to_binary(&MetaStakingExecuteMsg::Delegate { validator, amount })?,
+        msg: to_binary(&StakingExecuteMsg::Delegate { validator, amount })?,
         funds: vec![],
     };
 
@@ -163,7 +163,7 @@ pub fn receive_unstake(
 
     let msg = WasmMsg::Execute {
         contract_addr: config.meta_staking_contract_address.to_string(),
-        msg: to_binary(&MetaStakingExecuteMsg::Undelegate { validator, amount })?,
+        msg: to_binary(&StakingExecuteMsg::Undelegate { validator, amount })?,
         funds: vec![],
     };
 

--- a/contracts/mesh-consumer/src/testing/test_ibc_receive.rs
+++ b/contracts/mesh-consumer/src/testing/test_ibc_receive.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{
     testing::mock_env, to_binary, Addr, Decimal, IbcPacketReceiveMsg, Uint128, Validator, WasmMsg,
 };
+use mesh_apis::StakingExecuteMsg;
 use mesh_ibc::{ListValidatorsResponse, ProviderMsg, StakeResponse, UnstakeResponse};
 use mesh_testing::{
     addr,
@@ -51,7 +52,7 @@ fn test_ibc_receive_stake() {
         res.messages[0].msg,
         WasmMsg::Execute {
             contract_addr: STAKING_ADDR.to_string(),
-            msg: to_binary(&meta_staking::msg::ExecuteMsg::Delegate {
+            msg: to_binary(&StakingExecuteMsg::Delegate {
                 validator: VALIDATOR.to_string(),
                 amount: Uint128::new(100)
             })
@@ -75,7 +76,7 @@ fn test_ibc_receive_unstake() {
         res.messages[0].msg,
         WasmMsg::Execute {
             contract_addr: STAKING_ADDR.to_string(),
-            msg: to_binary(&meta_staking::msg::ExecuteMsg::Undelegate {
+            msg: to_binary(&StakingExecuteMsg::Undelegate {
                 validator: VALIDATOR.to_string(),
                 amount: Uint128::new(100)
             })

--- a/contracts/mesh-provider/src/ibc.rs
+++ b/contracts/mesh-provider/src/ibc.rs
@@ -146,7 +146,7 @@ pub fn receive_rewards(
     })?;
 
     // TODO: if calculation failed, we want to handle it as leftover funds? or send funds back to consumer and handle it there?
-    let ack = to_binary(&StdAck::success(&RewardsResponse {}))?;
+    let ack = StdAck::success(&RewardsResponse {});
 
     Ok(IbcReceiveResponse::new().set_ack(ack))
 }

--- a/contracts/meta-staking/src/bin/schema.rs
+++ b/contracts/meta-staking/src/bin/schema.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::write_api;
 
-use meta_staking::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use meta_staking::msg::{InstantiateMsg, QueryMsg};
+use mesh_apis::StakingExecuteMsg as ExecuteMsg;
 
 fn main() {
     write_api! {

--- a/contracts/meta-staking/src/bin/schema.rs
+++ b/contracts/meta-staking/src/bin/schema.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::write_api;
 
-use meta_staking::msg::{InstantiateMsg, QueryMsg};
 use mesh_apis::StakingExecuteMsg as ExecuteMsg;
+use meta_staking::msg::{InstantiateMsg, QueryMsg};
 
 fn main() {
     write_api! {

--- a/contracts/meta-staking/src/contract.rs
+++ b/contracts/meta-staking/src/contract.rs
@@ -7,8 +7,9 @@ use cw2::set_contract_version;
 use cw_utils::parse_reply_execute_data;
 
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, SudoMsg};
+use crate::msg::{InstantiateMsg, QueryMsg};
 use crate::state::{Config, CONFIG};
+use mesh_apis::{StakingExecuteMsg as ExecuteMsg, StakingSudoMsg as SudoMsg};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:meta-staking";

--- a/contracts/meta-staking/src/msg.rs
+++ b/contracts/meta-staking/src/msg.rs
@@ -13,34 +13,6 @@ pub struct MeshConsumerRecieveRewardsMsg {
 pub struct InstantiateMsg {}
 
 #[cw_serde]
-pub enum ExecuteMsg {
-    /// This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90).
-    /// `delegator_address` is automatically filled with the current contract's address.
-    Delegate {
-        validator: String,
-        amount: Uint128,
-    },
-    /// This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121).
-    /// `delegator_address` is automatically filled with the current contract's address.
-    Undelegate {
-        validator: String,
-        amount: Uint128,
-    },
-    /// This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50).
-    /// `delegator_address` is automatically filled with the current contract's address.
-    WithdrawDelegatorReward {
-        /// The `validator_address`
-        validator: String,
-    },
-    WithdrawToCostumer {
-        consumer: String,
-        validator: String,
-    },
-    /// Use for now, only admin can call - later we can remove if x/gov calls SudoMsg directly
-    Sudo(SudoMsg),
-}
-
-#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// AllDelegations will return all delegations by the consumer
@@ -67,23 +39,6 @@ pub enum QueryMsg {
         consumer: String,
         start: Option<String>,
         limit: Option<u32>,
-    },
-}
-
-#[cw_serde]
-pub enum SudoMsg {
-    /// HACK temporary workaround for the proof of concepy.
-    /// Governance will fund the meta-staking contract with native tokens.
-    /// In production, this would be accomplished by something like
-    /// a generic version of the Superfluid staking module which would
-    /// be in charge of minting and burning synthetic tokens.
-    /// Update list of consumers
-    AddConsumer {
-        consumer_address: String,
-        funds_available_for_staking: Coin,
-    },
-    RemoveConsumer {
-        consumer_address: String,
     },
 }
 

--- a/contracts/meta-staking/src/testing/test_rewards.rs
+++ b/contracts/meta-staking/src/testing/test_rewards.rs
@@ -6,7 +6,6 @@ use cosmwasm_std::{
 
 use crate::{
     contract::execute,
-    msg::ExecuteMsg,
     testing::utils::{
         executes::{undelegate, withdraw_rewards},
         queries::{query_consumer, query_rewards},
@@ -14,6 +13,7 @@ use crate::{
     },
     ContractError,
 };
+use mesh_apis::StakingExecuteMsg as ExecuteMsg;
 
 use mesh_testing::{
     constants::{CREATOR_ADDR, NATIVE_DENOM, VALIDATOR},

--- a/contracts/meta-staking/src/testing/utils/executes.rs
+++ b/contracts/meta-staking/src/testing/utils/executes.rs
@@ -2,7 +2,7 @@ use anyhow::Result as AnyResult;
 use cosmwasm_std::{coin, Addr, Uint128};
 use cw_multi_test::{App, AppResponse, Executor};
 
-use crate::msg::{ExecuteMsg, SudoMsg};
+use mesh_apis::{StakingExecuteMsg as ExecuteMsg, StakingSudoMsg};
 
 use mesh_testing::{constants::NATIVE_DENOM, macros::addr};
 
@@ -65,7 +65,7 @@ pub fn add_consumer(
     consumer_addr: &str,
     funds_avaiable: u128,
 ) -> AnyResult<AppResponse> {
-    let sudo_msg = SudoMsg::AddConsumer {
+    let sudo_msg = StakingSudoMsg::AddConsumer {
         consumer_address: consumer_addr.to_string(),
         funds_available_for_staking: coin(funds_avaiable, NATIVE_DENOM),
     };
@@ -84,7 +84,7 @@ pub fn remove_consumer(
     sender: &str,
     consumer_addr: &str,
 ) -> AnyResult<AppResponse> {
-    let sudo_msg = SudoMsg::RemoveConsumer {
+    let sudo_msg = StakingSudoMsg::RemoveConsumer {
         consumer_address: consumer_addr.to_string(),
     };
 

--- a/contracts/meta-staking/src/testing/utils/setup.rs
+++ b/contracts/meta-staking/src/testing/utils/setup.rs
@@ -13,7 +13,7 @@ use mesh_testing::{
 
 use crate::{
     contract::{execute, instantiate, sudo},
-    msg::{InstantiateMsg},
+    msg::InstantiateMsg,
 };
 use mesh_apis::{StakingExecuteMsg as ExecuteMsg, StakingSudoMsg};
 

--- a/contracts/meta-staking/src/testing/utils/setup.rs
+++ b/contracts/meta-staking/src/testing/utils/setup.rs
@@ -13,8 +13,9 @@ use mesh_testing::{
 
 use crate::{
     contract::{execute, instantiate, sudo},
-    msg::{ExecuteMsg, InstantiateMsg, SudoMsg as MetaStakingSudoMsg},
+    msg::{InstantiateMsg},
 };
+use mesh_apis::{StakingExecuteMsg as ExecuteMsg, StakingSudoMsg};
 
 use super::executes::{add_consumer, delegate};
 
@@ -180,7 +181,7 @@ pub fn setup_unit_with_delegation() -> (
     sudo(
         deps.as_mut(),
         env.clone(),
-        MetaStakingSudoMsg::AddConsumer {
+        StakingSudoMsg::AddConsumer {
             consumer_address: consumer_addr.to_string(),
             funds_available_for_staking: coin(10000, NATIVE_DENOM),
         },

--- a/packages/mesh-apis/src/lib.rs
+++ b/packages/mesh-apis/src/lib.rs
@@ -5,5 +5,5 @@ mod staking_execute;
 
 pub use claims::{ClaimProviderMsg, ClaimReceiverMsg};
 pub use consumer_execute::ConsumerExecuteMsg;
-pub use staking_execute::{StakingExecuteMsg, StakingSudoMsg};
 pub use slash::SlashMsg;
+pub use staking_execute::{StakingExecuteMsg, StakingSudoMsg};

--- a/packages/mesh-apis/src/lib.rs
+++ b/packages/mesh-apis/src/lib.rs
@@ -1,7 +1,9 @@
 mod claims;
 mod consumer_execute;
 mod slash;
+mod staking_execute;
 
 pub use claims::{ClaimProviderMsg, ClaimReceiverMsg};
 pub use consumer_execute::ConsumerExecuteMsg;
+pub use staking_execute::{StakingExecuteMsg, StakingSudoMsg};
 pub use slash::SlashMsg;

--- a/packages/mesh-apis/src/staking_execute.rs
+++ b/packages/mesh-apis/src/staking_execute.rs
@@ -1,0 +1,47 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Uint128, Coin};
+
+#[cw_serde]
+pub enum StakingExecuteMsg {
+    /// This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90).
+    /// `delegator_address` is automatically filled with the current contract's address.
+    Delegate {
+        validator: String,
+        amount: Uint128,
+    },
+    /// This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121).
+    /// `delegator_address` is automatically filled with the current contract's address.
+    Undelegate {
+        validator: String,
+        amount: Uint128,
+    },
+    /// This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50).
+    /// `delegator_address` is automatically filled with the current contract's address.
+    WithdrawDelegatorReward {
+        /// The `validator_address`
+        validator: String,
+    },
+    WithdrawToCostumer {
+        consumer: String,
+        validator: String,
+    },
+    /// Use for now, only admin can call - later we can remove if x/gov calls SudoMsg directly
+    Sudo(StakingSudoMsg),
+}
+
+#[cw_serde]
+pub enum StakingSudoMsg {
+    /// HACK temporary workaround for the proof of concepy.
+    /// Governance will fund the meta-staking contract with native tokens.
+    /// In production, this would be accomplished by something like
+    /// a generic version of the Superfluid staking module which would
+    /// be in charge of minting and burning synthetic tokens.
+    /// Update list of consumers
+    AddConsumer {
+        consumer_address: String,
+        funds_available_for_staking: Coin,
+    },
+    RemoveConsumer {
+        consumer_address: String,
+    },
+}

--- a/packages/mesh-apis/src/staking_execute.rs
+++ b/packages/mesh-apis/src/staking_execute.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Uint128, Coin};
+use cosmwasm_std::{Coin, Uint128};
 
 #[cw_serde]
 pub enum StakingExecuteMsg {


### PR DESCRIPTION
Moved meta-staking execute/sudo msgs to mesh-api to avoid the library feature issue, now consumer doesn't depend on meta-staking.

Commented one of the unstake in ts-relayer tests before we do withdraw, please note TODO: https://github.com/CosmWasm/mesh-security/compare/main...fix-ci#diff-9e6d7da7da5ed76351463fc4d29026b5cb54b2e61dd0a923fa0411e9430cc206R362
The above fails because we don't withdraw rewards on unstake/stake, so when we do withdraw rewards we calculate the rewards based on the most updated staked tokens amount, example:
1. Stake 5000 tokens
2. unstake 10 tokens
3. Withdraw rewards (here we get all rewards so far, but calculate it per 4990 tokens)
To make it correct, we need to withdraw and calculate rewards on step 2 before we do the unstake in contract.

The ts-relayer tests are still failing because of an issue in provider, I want to do the rust tests for provider first and spot the issue there quicker.